### PR TITLE
add an error message on program contact page if data doesn't load pro…

### DIFF
--- a/cpu-app/ClientApp/src/app/authenticated/program-contact/program-contact.component.ts
+++ b/cpu-app/ClientApp/src/app/authenticated/program-contact/program-contact.component.ts
@@ -35,6 +35,7 @@ export class ProgramContactComponent implements OnInit {
   emailRegex: RegExp;
   phoneRegex: RegExp;
   out: any;
+  errorState: boolean = false;
 
   constructor(
     private notificationQueueService: NotificationQueueService,
@@ -73,6 +74,11 @@ export class ProgramContactComponent implements OnInit {
 
             console.log("desired program info...");
             console.log(this.programApplication);
+
+            if (!this.programApplication) {
+              this.notificationQueueService.addNotification('An attempt at getting this program information was unsuccessful. If the problem persists please notify your ministry contact.', 'danger');
+              this.errorState = true;
+            }
 
             this.stateService.main.subscribe((m: Transmogrifier) => {
               this.trans = m;

--- a/cpu-app/ClientApp/src/app/core/models/transmogrifier.class.ts
+++ b/cpu-app/ClientApp/src/app/core/models/transmogrifier.class.ts
@@ -178,6 +178,14 @@ export class Transmogrifier {
       };
       ci.hasMailingAddress = true;
     } else {
+      ci.mailingAddress = {
+        city: null,
+        line1: null,
+        line2: null,
+        postalCode: null,
+        province: null,
+        country: 'Canada'
+      };
       ci.hasMailingAddress = false;
     }
     if (b.Organization._vsd_executivecontactid_value)

--- a/cpu-app/ClientApp/src/app/core/services/person.service.ts
+++ b/cpu-app/ClientApp/src/app/core/services/person.service.ts
@@ -17,7 +17,8 @@ export class PersonService {
 
   setPersons(users: iDynamicsPostUsers): Observable<any> {
     // console.log(users);
-    return this.http.post<any>(this.apiUrl, users, { headers: this.headers }).pipe(
+    let full_endpoint = `${this.apiUrl}/SetStaff`;
+    return this.http.post<any>(full_endpoint, users, { headers: this.headers }).pipe(
       retry(3),
       catchError(this.handleError)
     );

--- a/cpu-app/Controllers/DynamicsOrgController.cs
+++ b/cpu-app/Controllers/DynamicsOrgController.cs
@@ -38,9 +38,34 @@ namespace Gov.Cscp.Victims.Public.Controllers
             // turn the model into a string
             string modelString = System.Text.Json.JsonSerializer.Serialize(model);
             modelString = Helpers.Helpers.updateFortunecookieBindNull(modelString);
+
+            // modelString = "{\"BusinessBCeID\":\"fd889a40-14b2-e811-8163-480fcff4f621\",\"UserBCeID\":\"9e9b5111-51c9-e911-b80f-00505683fbf4\",\"StaffCollection\":[{\"_parentcustomerid_value\":null,\"address1_city\":null,\"address1_composite\":null,\"address1_line1\":null,\"address1_line2\":null,\"address1_postalcode\":null,\"address1_stateorprovince\":null,\"contactid\":null,\"emailaddress1\":null,\"fax\":null,\"firstname\":\"test\",\"fullname\":null,\"jobtitle\":null,\"lastname\":\"test\",\"middlename\":\"test\",\"mobilephone\":null,\"fortunecookietype\":\"Microsoft.Dynamics.CRM.contact\",\"vsd_bceid\":null,\"statecode\":null}]}";
             DynamicsResult result = await _dynamicsResultService.SetDataAsync(endpointUrl, modelString);
 
-            return StatusCode(200, result.result.ToString());
+            return StatusCode((int)result.statusCode, result.result.ToString());
         }
+
+
+        [HttpPost("SetStaff", Name = "SetStaff")]
+		public async Task<IActionResult> SetStaff([FromBody] OrganizationPost model)
+		{
+			if (model == null)
+			{
+				return StatusCode(502);
+
+			}
+			// build the url for posting to this endpoint
+			string endpointUrl = "vsd_SetCPUOrgContracts";
+
+			// make options for the json serializer
+			JsonSerializerOptions options = new JsonSerializerOptions();
+			options.IgnoreNullValues = true;
+			// turn the model into a string
+			string modelString = System.Text.Json.JsonSerializer.Serialize(model, options);
+			DynamicsResult result = await _dynamicsResultService.SetDataAsync(endpointUrl, modelString);
+
+			return StatusCode((int)result.statusCode, result.result.ToString());
+
+		}
     }
 }

--- a/cpu-app/Controllers/DynamicsProgramApplicationController.cs
+++ b/cpu-app/Controllers/DynamicsProgramApplicationController.cs
@@ -62,7 +62,7 @@ namespace Gov.Cscp.Victims.Public.Controllers
                 modelString = Helpers.Helpers.updateFortunecookieBindNull(modelString);
                 DynamicsResult result = await _dynamicsResultService.SetDataAsync(endpointUrl, modelString);
 
-                return StatusCode(200, result.result.ToString());
+                return StatusCode((int)result.statusCode, result.result.ToString());
             }
             finally { }
         }


### PR DESCRIPTION
…perly. Update transmogrifier to populate an empty mailing address object even if there is no mailing address on the contact information. To prevent errors when building back the save object for CRM API. Saving staff run into errors when sending null values. Temp solution is to have that call use old scraper for all null values.